### PR TITLE
Remove use of nightly feature that is now stable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,6 @@ println!("{:?}", compound_suggestions);
 ```
 */
 
-#![feature(duration_extras)]
-
 extern crate strsim;
 #[macro_use]
 extern crate derive_builder;


### PR DESCRIPTION
Fixes the following error when compiled with rustc 1.34.0:

    error[E0554]: #![feature] may not be used on the stable release channel

https://github.com/rust-lang/rust/issues/46507 has been stabilised as of https://github.com/rust-lang/rust/pull/50017.