### PR TITLE
Wasm: export only `UnicodeiStringStrategy`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,10 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 strsim = "^0.9"
-unidecode = "^0.3"
 derive_builder = "^0.9"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+unidecode = "^0.3"
 
 [target.wasm32-unknown-unknown.dependencies]
 serde = "^1.0.59"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ let mut unicode_symspell: SymSpell<UnicodeiStringStrategy> = SymSpell::default()
 ### Javascript Bindings
 
 This crate can be compiled against wasm32 target and exposes a SymSpell Class that can be used from Javascript as follow.
+Only `UnicodeiStringStrategy` is exported, meaning that if someone wants to manipulate ASCII only strings the dictionary and the sentences must be prepared in advance from JS.
 
 ```javascript
 const fs = require('fs');
@@ -69,7 +70,7 @@ const rust = require('./pkg');
 let dictionary = fs.readFileSync('data/frequency_dictionary_en_82_765.txt');
 let sentence = "whereis th elove hehad dated forImuch of thepast who couqdn'tread in sixtgrade and ins pired him";
 
-let symspell = new rust.SymSpell({ is_ascii: false, max_edit_distance: 2,  prefix_length: 7,  count_threshold: 1});
+let symspell = new rust.SymSpell({ max_edit_distance: 2,  prefix_length: 7,  count_threshold: 1});
 symspell.load_dictionary(dictionary.buffer, { term_index: 0,  count_index: 1, separator: " "});
 symspell.lookup_compound(sentence, 1);
 ```

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,10 +1,10 @@
 extern crate symspell;
 
 use std::time::Instant;
-use symspell::{AsciiStringStrategy, SymSpell, Verbosity};
+use symspell::{SymSpell, UnicodeiStringStrategy, Verbosity};
 
 fn main() {
-    let mut symspell: SymSpell<AsciiStringStrategy> = SymSpell::default();
+    let mut symspell: SymSpell<UnicodeiStringStrategy> = SymSpell::default();
 
     measure("load_dictionary", || {
         symspell.load_dictionary("data/frequency_dictionary_en_82_765.txt", 0, 1, " ");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ println!("{:?}", compound_suggestions);
 extern crate strsim;
 #[macro_use]
 extern crate derive_builder;
+
+#[cfg(not(target_arch = "wasm32"))]
 extern crate unidecode;
 
 #[cfg(target_arch = "wasm32")]
@@ -41,7 +43,9 @@ mod symspell;
 #[cfg(target_arch = "wasm32")]
 mod wasm;
 
-pub use string_strategy::{AsciiStringStrategy, StringStrategy, UnicodeiStringStrategy};
+#[cfg(not(target_arch = "wasm32"))]
+pub use string_strategy::AsciiStringStrategy;
+pub use string_strategy::{StringStrategy, UnicodeiStringStrategy};
 pub use suggestion::Suggestion;
 pub use symspell::{SymSpell, SymSpellBuilder, Verbosity};
 

--- a/src/string_strategy.rs
+++ b/src/string_strategy.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_arch = "wasm32"))]
 use unidecode::unidecode;
 
 pub trait StringStrategy: Clone + Default {
@@ -10,15 +11,18 @@ pub trait StringStrategy: Clone + Default {
     fn at(&self, s: &str, i: isize) -> Option<char>;
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone)]
 pub struct AsciiStringStrategy {}
 
+#[cfg(not(target_arch = "wasm32"))]
 impl Default for AsciiStringStrategy {
     fn default() -> AsciiStringStrategy {
         AsciiStringStrategy {}
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl StringStrategy for AsciiStringStrategy {
     fn new() -> Self {
         Self {}
@@ -102,6 +106,7 @@ impl StringStrategy for UnicodeiStringStrategy {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,5 +1,5 @@
 use std::str;
-use string_strategy::{AsciiStringStrategy, UnicodeiStringStrategy};
+use string_strategy::UnicodeiStringStrategy;
 use symspell::{SymSpell, SymSpellBuilder, Verbosity};
 use wasm_bindgen::prelude::*;
 
@@ -12,7 +12,6 @@ pub struct JSSuggestion {
 
 #[derive(Serialize, Deserialize)]
 pub struct InitParams {
-    is_ascii: bool,
     max_edit_distance: i32,
     prefix_length: i32,
     count_threshold: i32,
@@ -27,12 +26,7 @@ pub struct DictParams {
 
 #[wasm_bindgen(js_name = SymSpell)]
 pub struct JSSymSpell {
-    symspell: EJSSymSpell,
-}
-
-pub enum EJSSymSpell {
-    Ascii(SymSpell<AsciiStringStrategy>),
-    Unicode(SymSpell<UnicodeiStringStrategy>),
+    symspell: SymSpell<UnicodeiStringStrategy>,
 }
 
 #[wasm_bindgen(js_class = SymSpell)]
@@ -40,7 +34,6 @@ impl JSSymSpell {
     #[wasm_bindgen(constructor)]
     pub fn new(parameters: &JsValue) -> Result<JSSymSpell, JsValue> {
         let params: InitParams;
-        let ret: JSSymSpell;
 
         if let Ok(i) = parameters.into_serde() {
             params = i;
@@ -48,28 +41,13 @@ impl JSSymSpell {
             return Err(JsValue::from("Unable to parse arguments"));
         }
 
-        if params.is_ascii {
-            ret = JSSymSpell {
-                symspell: EJSSymSpell::Ascii(
-                    SymSpellBuilder::default()
-                        .max_dictionary_edit_distance(params.max_edit_distance as i64)
-                        .prefix_length(params.prefix_length as i64)
-                        .count_threshold(params.count_threshold as i64)
-                        .build()?,
-                ),
-            };
-        } else {
-            ret = JSSymSpell {
-                symspell: EJSSymSpell::Unicode(
-                    SymSpellBuilder::default()
-                        .max_dictionary_edit_distance(params.max_edit_distance as i64)
-                        .prefix_length(params.prefix_length as i64)
-                        .count_threshold(params.count_threshold as i64)
-                        .build()?,
-                ),
-            };
-        }
-        Ok(ret)
+        Ok(JSSymSpell {
+            symspell: SymSpellBuilder::default()
+                .max_dictionary_edit_distance(params.max_edit_distance as i64)
+                .prefix_length(params.prefix_length as i64)
+                .count_threshold(params.count_threshold as i64)
+                .build()?,
+        })
     }
 
     // Expose numeric params as i32 and cast to i64 is required bc BigInt doesn'tplay well in some
@@ -90,20 +68,12 @@ impl JSSymSpell {
         }
 
         for line in corpus.lines() {
-            match self.symspell {
-                EJSSymSpell::Ascii(ref mut i) => i.load_dictionary_line(
-                    &line,
-                    params.term_index as i64,
-                    params.count_index as i64,
-                    &params.separator,
-                ),
-                EJSSymSpell::Unicode(ref mut i) => i.load_dictionary_line(
-                    &line,
-                    params.term_index as i64,
-                    params.count_index as i64,
-                    &params.separator,
-                ),
-            };
+            self.symspell.load_dictionary_line(
+                &line,
+                params.term_index as i64,
+                params.count_index as i64,
+                &params.separator,
+            );
         }
         Ok(())
     }
@@ -113,10 +83,7 @@ impl JSSymSpell {
         input: &str,
         edit_distance: i32,
     ) -> Result<Vec<JsValue>, JsValue> {
-        let res = match self.symspell {
-            EJSSymSpell::Ascii(ref i) => i.lookup_compound(input, edit_distance as i64),
-            EJSSymSpell::Unicode(ref i) => i.lookup_compound(input, edit_distance as i64),
-        };
+        let res = self.symspell.lookup_compound(input, edit_distance as i64);
         Ok(res
             .into_iter()
             .map(|sugg| {
@@ -143,12 +110,9 @@ impl JSSymSpell {
             _ => return Err(JsValue::from("Verbosity must be between 0 and 2")),
         };
 
-        let res = match self.symspell {
-            EJSSymSpell::Ascii(ref i) => i.lookup(input, sym_verbosity, max_edit_distance as i64),
-            EJSSymSpell::Unicode(ref i) => {
-                i.lookup(&input, sym_verbosity, max_edit_distance as i64)
-            }
-        };
+        let res = self
+            .symspell
+            .lookup(&input, sym_verbosity, max_edit_distance as i64);
 
         Ok(res
             .into_iter()
@@ -172,7 +136,6 @@ mod tests {
     #[wasm_bindgen_test]
     fn test_sentence() {
         let init_args = InitParams {
-            is_ascii: false,
             max_edit_distance: 2,
             prefix_length: 7,
             count_threshold: 1,


### PR DESCRIPTION
This PR removes support from wasm32 target for `AsciiStringStrategy` processing.
The reason behind this that `unidecode` brings a lot of code bloat and the result of this is a three times smaller wasm module.

``` 
symspell on master $ wasm-pack build --release --target web && ls -lh pkg
[INFO]: Checking for the Wasm target...
[INFO]: Compiling to Wasm...
   Compiling symspell v0.2.0 (/home/user/Works/symspell/symspell)
    Finished release [optimized] target(s) in 2.27s
[INFO]: Installing wasm-bindgen...
[INFO]: :-) Done in 2.35s
[INFO]: :-) Your wasm pkg is ready to publish at ./pkg.
total 820K
-rw-r--r-- 1 user user 1.1K Nov 18 12:01 LICENSE
-rw-r--r-- 1 user user  501 Nov 18 12:01 package.json
-rw-r--r-- 1 user user 2.6K Nov 18 12:01 README.md
-rw-r--r-- 1 user user  657 Nov 18 12:01 symspell_bg.d.ts
-rw-r--r-- 1 user user 789K Nov 18 12:01 symspell_bg.wasm
-rw-r--r-- 1 user user  972 Nov 18 12:01 symspell.d.ts
-rw-r--r-- 1 user user 8.0K Nov 18 12:01 symspell.js
```

``` 
symspell on wasm-rm-asciistrategy $ wasm-pack build --release --target web && ls -lh pkg
[INFO]: Checking for the Wasm target...
[INFO]: Compiling to Wasm...
   Compiling symspell v0.2.0 (/home/user/Works/symspell/symspell)
    Finished release [optimized] target(s) in 1.95s
[INFO]: Installing wasm-bindgen...
[INFO]: :-) Done in 2.04s
[INFO]: :-) Your wasm pkg is ready to publish at ./pkg.
total 224K
-rw-r--r-- 1 user user 1.1K Nov 18 12:01 LICENSE
-rw-r--r-- 1 user user  501 Nov 18 12:01 package.json
-rw-r--r-- 1 user user 2.7K Nov 18 12:01 README.md
-rw-r--r-- 1 user user  657 Nov 18 12:01 symspell_bg.d.ts
-rw-r--r-- 1 user user 196K Nov 18 12:01 symspell_bg.wasm
-rw-r--r-- 1 user user  972 Nov 18 12:01 symspell.d.ts
-rw-r--r-- 1 user user 8.0K Nov 18 12:01 symspell.js
```