### PR TITLE
rename UnicodeiStringStrategy to UnicodeStringStrategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ let mut symspell: SymSpell<AsciiStringStrategy> = SymSpellBuilder::default()
 String strategy is abstraction for string manipulation, for example preprocessing.
 
 There are two strategies included:
-* `UnicodeiStringStrategy`
+* `UnicodeStringStrategy`
     * Doesn't do any prepocessing and handles strings as they are.
 * `AsciiStringStrategy`
     * Transliterates strings into ASCII only characters.
@@ -55,13 +55,13 @@ To configure string strategy just pass it as a type parameter:
 
 ```rust
 let mut ascii_symspell: SymSpell<AsciiStringStrategy> = SymSpell::default();
-let mut unicode_symspell: SymSpell<UnicodeiStringStrategy> = SymSpell::default();
+let mut unicode_symspell: SymSpell<UnicodeStringStrategy> = SymSpell::default();
 ```
 
 ### Javascript Bindings
 
 This crate can be compiled against wasm32 target and exposes a SymSpell Class that can be used from Javascript as follow.
-Only `UnicodeiStringStrategy` is exported, meaning that if someone wants to manipulate ASCII only strings the dictionary and the sentences must be prepared in advance from JS.
+Only `UnicodeStringStrategy` is exported, meaning that if someone wants to manipulate ASCII only strings the dictionary and the sentences must be prepared in advance from JS.
 
 ```javascript
 const fs = require('fs');

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,10 +1,10 @@
 extern crate symspell;
 
 use std::time::Instant;
-use symspell::{SymSpell, UnicodeiStringStrategy, Verbosity};
+use symspell::{SymSpell, UnicodeStringStrategy, Verbosity};
 
 fn main() {
-    let mut symspell: SymSpell<UnicodeiStringStrategy> = SymSpell::default();
+    let mut symspell: SymSpell<UnicodeStringStrategy> = SymSpell::default();
 
     measure("load_dictionary", || {
         symspell.load_dictionary("data/frequency_dictionary_en_82_765.txt", 0, 1, " ");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ mod wasm;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use string_strategy::AsciiStringStrategy;
-pub use string_strategy::{StringStrategy, UnicodeiStringStrategy};
+pub use string_strategy::{StringStrategy, UnicodeStringStrategy, UnicodeiStringStrategy};
 pub use suggestion::Suggestion;
 pub use symspell::{SymSpell, SymSpellBuilder, Verbosity};
 

--- a/src/string_strategy.rs
+++ b/src/string_strategy.rs
@@ -59,16 +59,21 @@ impl StringStrategy for AsciiStringStrategy {
     }
 }
 
-#[derive(Clone)]
-pub struct UnicodeiStringStrategy {}
 
-impl Default for UnicodeiStringStrategy {
-    fn default() -> UnicodeiStringStrategy {
-        UnicodeiStringStrategy {}
+
+// backward compatibility on typo
+pub type UnicodeiStringStrategy = UnicodeStringStrategy;
+
+#[derive(Clone)]
+pub struct UnicodeStringStrategy {}
+
+impl Default for UnicodeStringStrategy {
+    fn default() -> UnicodeStringStrategy {
+        UnicodeStringStrategy {}
     }
 }
 
-impl StringStrategy for UnicodeiStringStrategy {
+impl StringStrategy for UnicodeStringStrategy {
     fn new() -> Self {
         Self {}
     }
@@ -144,5 +149,10 @@ mod tests {
     #[test]
     fn ascii_at_over_limit() {
         assert_eq!(AsciiStringStrategy::new().at("daleko", 6), None);
+    }
+
+    #[test]
+    fn unicodei_strategy() {
+        assert_eq!(UnicodeiStringStrategy::new().prepare("ciccio"), "ciccio");
     }
 }

--- a/src/symspell.rs
+++ b/src/symspell.rs
@@ -698,12 +698,12 @@ impl<T: StringStrategy> SymSpell<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use string_strategy::UnicodeiStringStrategy;
+    use string_strategy::UnicodeStringStrategy;
 
     #[test]
     fn test_lookup_compound() {
         let edit_distance_max = 2;
-        let mut sym_spell = SymSpell::<UnicodeiStringStrategy>::default();
+        let mut sym_spell = SymSpell::<UnicodeStringStrategy>::default();
         sym_spell.load_dictionary("./data/frequency_dictionary_en_82_765.txt", 0, 1, " ");
 
         let typo = "whereis th elove";

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,5 +1,5 @@
 use std::str;
-use string_strategy::UnicodeiStringStrategy;
+use string_strategy::UnicodeStringStrategy;
 use symspell::{SymSpell, SymSpellBuilder, Verbosity};
 use wasm_bindgen::prelude::*;
 
@@ -26,7 +26,7 @@ pub struct DictParams {
 
 #[wasm_bindgen(js_name = SymSpell)]
 pub struct JSSymSpell {
-    symspell: SymSpell<UnicodeiStringStrategy>,
+    symspell: SymSpell<UnicodeStringStrategy>,
 }
 
 #[wasm_bindgen(js_class = SymSpell)]


### PR DESCRIPTION
This rename UnicodeiStringStrategy, while mantaining an alias for
backward compatibility