### PR TITLE
Add bigram support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 target/
-data/*
 
 examples/*_ignored.rs

--- a/src/symspell.rs
+++ b/src/symspell.rs
@@ -156,7 +156,7 @@ impl<T: StringStrategy> SymSpell<T> {
         if line_parts.len() >= line_parts_len {
             let key = if separator == " " {
                 self.string_strategy.prepare(&format!(
-                    "{}{}",
+                    "{} {}",
                     line_parts[term_index as usize],
                     line_parts[(term_index + 1) as usize]
                 ))
@@ -881,13 +881,12 @@ mod tests {
             2,
             " ",
         );
-
-        let typo = "the bigjest playrs in te strogsommer film slatew ith plety of funn";
-        let correction = "the biggest players in the strong summer film slate with plenty of fun";
+        let typo = "Can yu readthis";
+        let correction = "can you read this";
         let results = sym_spell.lookup_compound(typo, edit_distance_max);
         assert_eq!(1, results.len());
         assert_eq!(correction, results[0].term);
-        assert_eq!(9, results[0].distance);
-        assert_eq!(0, results[0].count);
+        assert_eq!(3, results[0].distance);
+        assert_eq!(1366, results[0].count);
     }
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -169,11 +169,7 @@ mod tests {
             count_threshold: 1,
         };
         let mut speller = JSSymSpell::new(&JsValue::from_serde(&init_args).unwrap()).unwrap();
-        let sentence = "wher";
         let dict = "where 360468339\ninfo 352363058".as_bytes();
-        let bigram_dict = "this is 1111\nwhere is 1234".as_bytes();
-        let expected = "where";
-
         let dict_args = DictParams {
             term_index: 0,
             count_index: 1,
@@ -182,9 +178,18 @@ mod tests {
         speller
             .load_dictionary(dict, &JsValue::from_serde(&dict_args).unwrap())
             .unwrap();
+        
+        let bigram_dict = "this is 1111\nwhere is 1234".as_bytes();
+        let bigram_dict_args = DictParams {
+            term_index: 0,
+            count_index: 2,
+            separator: String::from(" "),
+        };
         speller
-            .load_bigram_dictionary(bigram_dict, &JsValue::from_serde(&dict_args).unwrap())
+            .load_bigram_dictionary(bigram_dict, &JsValue::from_serde(&bigram_dict_args).unwrap())
             .unwrap();
+        let sentence = "wher";
+        let expected = "where";
         let result: JSSuggestion = speller.lookup_compound(sentence, 1).unwrap()[0]
             .into_serde()
             .unwrap();

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -181,6 +181,8 @@ mod tests {
         };
         speller
             .load_dictionary(dict, &JsValue::from_serde(&dict_args).unwrap())
+            .unwrap();
+        speller
             .load_bigram_dictionary(bigram_dict, &JsValue::from_serde(&dict_args).unwrap())
             .unwrap();
         let result: JSSuggestion = speller.lookup_compound(sentence, 1).unwrap()[0]

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -78,6 +78,34 @@ impl JSSymSpell {
         Ok(())
     }
 
+    // Expose numeric params as i32 and cast to i64 is required bc BigInt doesn'tplay well in some
+    // browsers.
+    pub fn load_bigram_dictionary(&mut self, input: &[u8], args: &JsValue) -> Result<(), JsValue> {
+        let params: DictParams;
+        if let Ok(i) = args.into_serde() {
+            params = i;
+        } else {
+            return Err(JsValue::from("Unable to parse arguments"));
+        }
+
+        let corpus: &str;
+        if let Ok(i) = str::from_utf8(input) {
+            corpus = i;
+        } else {
+            return Err(JsValue::from("Invalid UTF-8"));
+        }
+
+        for line in corpus.lines() {
+            self.symspell.load_bigram_dictionary_line(
+                &line,
+                params.term_index as i64,
+                params.count_index as i64,
+                &params.separator,
+            );
+        }
+        Ok(())
+    }
+
     pub fn lookup_compound(
         &self,
         input: &str,
@@ -143,6 +171,7 @@ mod tests {
         let mut speller = JSSymSpell::new(&JsValue::from_serde(&init_args).unwrap()).unwrap();
         let sentence = "wher";
         let dict = "where 360468339\ninfo 352363058".as_bytes();
+        let bigram_dict = "this is 1111\nwhere is 1234".as_bytes();
         let expected = "where";
 
         let dict_args = DictParams {
@@ -152,6 +181,7 @@ mod tests {
         };
         speller
             .load_dictionary(dict, &JsValue::from_serde(&dict_args).unwrap())
+            .load_bigram_dictionary(bigram_dict, &JsValue::from_serde(&dict_args).unwrap())
             .unwrap();
         let result: JSSuggestion = speller.lookup_compound(sentence, 1).unwrap()[0]
             .into_serde()


### PR DESCRIPTION
I copied the bigram logic from symspell c# repository for lookup compound.
My test doesn't hit the bigram code path. Any example to hit the naive bayes/bigram code path and distinguish between the two would be great.

I have also refactored the corpus word count to be a member of symspell struct instead of static global. It should logically be set when loading a dictionary, but that would break backward compatibility. If its ok, we can increment versions and break compatibility.