### PR TITLE
Write progress messages to stderr

### DIFF
--- a/src/symspell.rs
+++ b/src/symspell.rs
@@ -88,7 +88,7 @@ impl<T: StringStrategy> SymSpell<T> {
 
         for (i, line) in sr.lines().enumerate() {
             if i % 50_000 == 0 {
-                println!("progress: {}", i);
+                eprintln!("progress: {}", i);
             }
             let line_str = line.unwrap();
             self.load_dictionary_line(&line_str, term_index, count_index, separator);
@@ -146,7 +146,7 @@ impl<T: StringStrategy> SymSpell<T> {
         let sr = BufReader::new(file);
         for (i, line) in sr.lines().enumerate() {
             if i % 50_000 == 0 {
-                println!("progress: {}", i);
+                eprintln!("progress: {}", i);
             }
             let line_str = line.unwrap();
             self.load_bigram_dictionary_line(&line_str, term_index, count_index, &separator);


### PR DESCRIPTION
Hi @reneklacan, I really appreciate the Rust implementation. 

Is it possible for you to switch the symspell progress output to **stderr** instead of stdout?

Thanks!

