### PR TITLE
Use immutable strings to store dictionaries

### DIFF
--- a/src/suggestion.rs
+++ b/src/suggestion.rs
@@ -15,9 +15,10 @@ impl Suggestion {
             count: 0,
         }
     }
-    pub fn new(term: &str, distance: i64, count: i64) -> Suggestion {
+
+    pub fn new(term: impl Into<String>, distance: i64, count: i64) -> Suggestion {
         Suggestion {
-            term: term.to_string(),
+            term: term.into(),
             distance,
             count,
         }


### PR DESCRIPTION
Since there's no need to mutate words in internal hashes it would be more optimal to use `Box<str>` instead of `String`.
For example in my case of ~5.6M unigrams and bigrams in total memory consumption is 4.77 Gb with `Box<str>` version while with `String` it's 5.68 Gb (+19%).